### PR TITLE
[15] Some clean-up

### DIFF
--- a/EWEAMainWindow.h
+++ b/EWEAMainWindow.h
@@ -5,6 +5,7 @@
 #include <QMainWindow>
 #include <QPointer>
 
+#include <map>
 #include <vector>
 
 class QDragEnterEvent;
@@ -26,10 +27,16 @@ private:
     void
     dropEvent( QDropEvent* dropEvent ) override;
 
+    void
+    setUpLoadedFilesList();
+
+    void
+    unloadSelectedArtifacts();
+
 private:
     QPointer<QListWidget>                m_loadedFilesList;
-    std::vector<QPointer<QTabWidget>>    m_executableArtifactViewers;
     QPointer<QStackedWidget>             m_artifactViewersStack;
+    std::map<std::string, QTabWidget*>   m_artifactPathToViewerMap;
 };
 
 #endif // EWEAMAINWINDOW_H

--- a/EXEViewer.cpp
+++ b/EXEViewer.cpp
@@ -35,38 +35,10 @@ EXEViewer::EXEViewer( EXEFile&& loadedEXEFile,
 : QTabWidget( parentWidget )
 , m_loadedEXEFile( std::move( loadedEXEFile ) )
 {
-    setUpRawDataTab();
     setUpFileHeadersTab();
     setUpSectionHeadersTab();
     setUpImportsTab();
     setUpExportsTab();
-}
-
-void
-EXEViewer::setUpRawDataTab()
-{
-    auto rawDataViewer = new QPlainTextEdit;
-    addTab( rawDataViewer, "Raw Data" );
-
-    rawDataViewer->setReadOnly( true );
-
-    auto rawDataAsText = QString();
-    for ( auto i = 0; i < m_loadedEXEFile.rawBytes.size(); i++ )
-    {
-        rawDataAsText += QString( " %1" ).arg( m_loadedEXEFile.rawBytes[ i ],
-                                               2, 16, QChar( '0' ) ).toUpper();
-
-        if ( ( i + 1 ) % 24 == 0 )
-        {
-            rawDataViewer->appendPlainText( rawDataAsText );
-            rawDataAsText.clear();
-        }
-
-        if ( ( i % 1024 ) == 0 )
-        {
-            QApplication::processEvents();
-        }
-    }
 }
 
 void

--- a/EXEViewer.h
+++ b/EXEViewer.h
@@ -16,9 +16,6 @@ public:
 
 private:
     void
-    setUpRawDataTab();
-
-    void
     setUpFileHeadersTab();
 
     void


### PR DESCRIPTION
- Removed the "Raw Data" tab since I haven't found a use for it (and don't expect to). The underlying raw data is still available in case there is other information I need to extract and display from it.

- Made it possible to switch between multiple open files (it was already possible to *load* multiple files). We can now view information for a file by double-clicking on it in the file list (the double-click is intended to clear any multi-selection).

- Made it possible to unload loaded files (by right-clicking on them in the file list and selecting "Unload selection" in the context menu). The sole reason the file list widget has multi-selection enabled is to allow multiple files to be unloaded at once.