### PR TITLE
[19] Enabled loading .obj files and showing some basic info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(ewea
                main.cpp
                EWEAMainWindow.cpp
                EXEViewer.cpp
+               OBJViewer.cpp
                PEFiles.cpp
                PEFormat.cpp
               )

--- a/EWEAMainWindow.cpp
+++ b/EWEAMainWindow.cpp
@@ -1,6 +1,7 @@
 
 #include "EWEAMainWindow.h"
 #include "EXEViewer.h"
+#include "OBJViewer.h"
 #include "PEFiles.h"
 
 #include <QDragEnterEvent>
@@ -58,7 +59,8 @@ EWEAMainWindow::dropEvent( QDropEvent* dropEvent )
             auto pathOfExecutableFile = fileURL.toLocalFile();
 
             if ( not pathOfExecutableFile.endsWith( ".exe" ) and
-                 not pathOfExecutableFile.endsWith( ".dll" ) )
+                 not pathOfExecutableFile.endsWith( ".dll" ) and
+                 not pathOfExecutableFile.endsWith( ".obj" ) )
             {
                 continue;
             }
@@ -71,6 +73,14 @@ EWEAMainWindow::dropEvent( QDropEvent* dropEvent )
             {
                 auto loadedEXEFile = loadEXEFile( pathOfExecutableFile.toStdString() );
                 auto artifactViewer = new EXEViewer( std::move( loadedEXEFile ) );
+
+                m_artifactViewersStack->addWidget( artifactViewer );
+                m_artifactPathToViewerMap[pathOfExecutableFile.toStdString()] = artifactViewer;
+            }
+            else if ( pathOfExecutableFile.endsWith( ".obj" ) )
+            {
+                auto loadedOBJFile = loadOBJFile( pathOfExecutableFile.toStdString() );
+                auto artifactViewer = new OBJViewer( std::move( loadedOBJFile ) );
 
                 m_artifactViewersStack->addWidget( artifactViewer );
                 m_artifactPathToViewerMap[pathOfExecutableFile.toStdString()] = artifactViewer;

--- a/OBJViewer.cpp
+++ b/OBJViewer.cpp
@@ -1,0 +1,158 @@
+
+#include "OBJViewer.h"
+
+#include <QGroupBox>
+#include <QLabel>
+#include <QScrollArea>
+#include <QVBoxLayout>
+
+namespace
+{
+    void
+    setUpNTFileHeaderWidgets( PE::NTFileHeader const& ntFileHeader,
+                              QGroupBox* ntFileHeaderWidgetsContainer );
+}
+
+OBJViewer::OBJViewer( OBJFile&& loadedOBJFile,
+                      QWidget* parentWidget )
+: QTabWidget( parentWidget )
+, m_loadedOBJFile( std::move( loadedOBJFile ) )
+{
+    setUpFileHeadersTab();
+    setUpSectionHeadersTab();
+}
+
+void
+OBJViewer::setUpFileHeadersTab()
+{
+    auto headersTabRootWidget = new QWidget;
+    addTab( headersTabRootWidget, "File Headers" );
+
+    auto headersTabMainLayout = new QVBoxLayout( headersTabRootWidget );
+
+    auto ntFileHeaderWidgetsContainer = new QGroupBox( "NT File Header" );
+    headersTabMainLayout->addWidget( ntFileHeaderWidgetsContainer );
+
+    headersTabMainLayout->addStretch();
+
+    setUpNTFileHeaderWidgets( m_loadedOBJFile.ntFileHeader, ntFileHeaderWidgetsContainer );
+}
+
+void
+OBJViewer::setUpSectionHeadersTab()
+{
+    auto sectionHeadersScrollWidget = new QScrollArea;
+    addTab( sectionHeadersScrollWidget, "Section Headers" );
+
+    auto sectionHeadersTabRootWidget = new QWidget;
+    auto sectionHeadersTabMainLayout = new QGridLayout( sectionHeadersTabRootWidget );
+
+    auto const& sectionHeadersNameToInfo = m_loadedOBJFile.sectionHeaders;
+    auto currentRow = 0;
+    auto currentColumn = 0;
+
+    for ( auto const& [sectionName, sectionHeaders] : sectionHeadersNameToInfo )
+    {
+        for ( auto const& sectionHeader : sectionHeaders )
+        {
+            auto sectionHeaderWidgetsContainer =
+                new QGroupBox( QString::fromStdString( sectionName ) );
+            sectionHeadersTabMainLayout->addWidget( sectionHeaderWidgetsContainer,
+                                                    currentRow,
+                                                    currentColumn );
+            currentColumn++;
+            if ( currentColumn >= 2 )
+            {
+                currentColumn = 0;
+                currentRow++;
+            }
+
+            auto sectionHeaderWidgetsLayout = new QVBoxLayout( sectionHeaderWidgetsContainer );
+
+            auto sectionSizeLabel =
+                new QLabel( QString( "Size in memory: %1" )
+                                .arg( sectionHeader.sectionSizeInBytesInMemory ) );
+            sectionHeaderWidgetsLayout->addWidget( sectionSizeLabel );
+
+            auto const sectionBaseAddressAsHexString =
+                QString( "%1" ).arg( sectionHeader.sectionBaseAddressInMemory,
+                                     8, 16, QChar( '0' ) ).toUpper();
+            auto sectionBaseAddressLabel =
+                new QLabel( QString( "Base address in memory: 0x%1" )
+                                .arg( sectionBaseAddressAsHexString ) );
+            sectionHeaderWidgetsLayout->addWidget( sectionBaseAddressLabel );
+
+            auto sizeOfRawDataLabel =
+                new QLabel( QString( "Size of raw data: %1" )
+                                .arg( sectionHeader.sizeOfRawDataInBytes ) );
+            sectionHeaderWidgetsLayout->addWidget( sizeOfRawDataLabel );
+
+            auto const pointerToRawDataAsHexString =
+                QString( "%1" ).arg( sectionHeader.pointerToRawData,
+                                     8, 16, QChar( '0' ) ).toUpper();
+            auto pointerToRawDataLabel =
+                new QLabel( QString( "Pointer to raw data: 0x%1" )
+                                .arg( pointerToRawDataAsHexString ) );
+            sectionHeaderWidgetsLayout->addWidget( pointerToRawDataLabel );
+
+            auto const pointerToRelocationsAsHexString =
+                QString( "%1" ).arg( sectionHeader.pointerToRelocations,
+                                     8, 16, QChar( '0' ) ).toUpper();
+            auto pointerToRelocationsLabel =
+                new QLabel( QString( "Pointer to relocations: 0x%1" )
+                                .arg( pointerToRelocationsAsHexString ) );
+            sectionHeaderWidgetsLayout->addWidget( pointerToRelocationsLabel );
+
+            auto const pointerToLineNumbersAsHexString =
+                QString( "%1" ).arg( sectionHeader.pointerToLineNumbers,
+                                     8, 16, QChar( '0' ) ).toUpper();
+            auto pointerToLineNumbersLabel =
+                new QLabel( QString( "Pointer to line numbers: 0x%1" )
+                                .arg( pointerToLineNumbersAsHexString ) );
+            sectionHeaderWidgetsLayout->addWidget( pointerToLineNumbersLabel );
+
+            auto numberOfRelocationsLabel =
+                new QLabel( QString( "Number of relocations: %1" )
+                                .arg( sectionHeader.numberOfRelocations ) );
+            sectionHeaderWidgetsLayout->addWidget( numberOfRelocationsLabel );
+
+            auto numberOfLineNumberEntriesLabel =
+                new QLabel( QString( "Number of line number entries: %1" )
+                                .arg( sectionHeader.numberOfLineNumberEntries ) );
+            sectionHeaderWidgetsLayout->addWidget( numberOfLineNumberEntriesLabel );
+        }
+    }
+
+    sectionHeadersScrollWidget->setWidget( sectionHeadersTabRootWidget );
+}
+
+namespace
+{
+    void
+    setUpNTFileHeaderWidgets( PE::NTFileHeader const& ntFileHeader,
+                              QGroupBox* ntFileHeaderWidgetsContainer )
+    {
+        auto ntFileHeaderWidgetsLayout = new QVBoxLayout( ntFileHeaderWidgetsContainer );
+
+        auto optionalHeaderSizeLabel =
+            new QLabel( QString( "Size of optional header: %1" )
+                            .arg( ntFileHeader.sizeOfOptionalHeader ) );
+        ntFileHeaderWidgetsLayout->addWidget( optionalHeaderSizeLabel );
+
+        auto const targetMachineArchitectureHexString =
+            QString( "%1" ).arg( ntFileHeader.targetMachineArchitecture,
+                                 4, 16, QChar( '0' ) ).toUpper();
+        auto const targetMachineArchitectureName =
+            QString::fromStdString( PE::getMachineArchitectureName( ntFileHeader.targetMachineArchitecture ) );
+        auto targetMachineArchitectureLabel =
+            new QLabel( QString( "Target machine architecture: 0x%1 (%2)" )
+                            .arg( targetMachineArchitectureHexString )
+                            .arg( targetMachineArchitectureName ) );
+        ntFileHeaderWidgetsLayout->addWidget( targetMachineArchitectureLabel );
+
+        auto numberOfSectionsLabel =
+            new QLabel( QString( "Number of sections: %1" )
+                            .arg( ntFileHeader.numberOfSections ) );
+        ntFileHeaderWidgetsLayout->addWidget( numberOfSectionsLabel );
+    }
+}

--- a/OBJViewer.h
+++ b/OBJViewer.h
@@ -1,0 +1,28 @@
+
+#ifndef OBJVIEWER_H
+#define OBJVIEWER_H
+
+#include "PEFiles.h"
+
+#include <QTabWidget>
+
+class OBJViewer : public QTabWidget
+{
+    Q_OBJECT
+
+public:
+    OBJViewer( OBJFile&& loadedOBJFile,
+               QWidget* parentWidget = nullptr );
+
+private:
+    void
+    setUpFileHeadersTab();
+
+    void
+    setUpSectionHeadersTab();
+
+private:
+    OBJFile    m_loadedOBJFile;
+};
+
+#endif // OBJVIEWER_H

--- a/PEFiles.h
+++ b/PEFiles.h
@@ -10,7 +10,6 @@
 
 struct EXEFile
 {
-    std::vector<unsigned char>                           rawBytes;
     PE::DOSHeader                                        dosHeader;
     unsigned long                                        ntSignature;
     PE::NTFileHeader                                     ntFileHeader;
@@ -24,5 +23,14 @@ struct EXEFile
 
 EXEFile
 loadEXEFile( std::string const& pathOfExecutableFile );
+
+struct OBJFile
+{
+    PE::NTFileHeader                                         ntFileHeader;
+    std::map<std::string, std::vector<PE::SectionHeader>>    sectionHeaders;
+};
+
+OBJFile
+loadOBJFile( std::string const& pathOfObjectFile );
 
 #endif // PEFILES_H

--- a/PEFormat.cpp
+++ b/PEFormat.cpp
@@ -146,6 +146,25 @@ namespace PE
         return sectionNameToHeader;
     }
 
+    std::map<std::string, std::vector<SectionHeader>>
+    extractSectionHeadersFromOBJFile( unsigned char const* rawBytesFromStartOfSectionHeaders,
+                                      int const numberOfSections )
+    {
+        auto sectionNameToHeader = std::map<std::string, std::vector<SectionHeader>>{};
+
+        for ( auto i = 0; i < numberOfSections; i++ )
+        {
+            auto const& sectionHeader =
+                *reinterpret_cast<SectionHeader const*>( rawBytesFromStartOfSectionHeaders +
+                                                         i * sizeof( SectionHeader ) );
+            auto const sectionName = getSectionName( sectionHeader.sectionNameAsNumber );
+
+            sectionNameToHeader[sectionName].push_back( sectionHeader );
+        }
+
+        return sectionNameToHeader;
+    }
+
     std::map<std::string, std::vector<unsigned char>>
     extractRawSectionContents( unsigned char const* rawBytesFromStartOfFile,
                                std::map<std::string, SectionHeader> const& sectionHeaders )

--- a/PEFormat.h
+++ b/PEFormat.h
@@ -81,6 +81,10 @@ namespace PE
     extractSectionHeaders( unsigned char const* rawBytesFromStartOfSectionHeaders,
                            int const numberOfSections );
 
+    std::map<std::string, std::vector<SectionHeader>>
+    extractSectionHeadersFromOBJFile( unsigned char const* rawBytesFromStartOfSectionHeaders,
+                                      int const numberOfSections );
+
     std::map<std::string, std::vector<unsigned char>>
     extractRawSectionContents( unsigned char const* rawBytesFromStartOfFile,
                                std::map<std::string, SectionHeader> const& sectionHeaders );


### PR DESCRIPTION
Made it possible to load .obj files and show the NT file header and the section headers. The implementation is in line with that for .exe and .dll files, one big difference being that .obj files have multiple sections with identical names (from what I understand, these are combined into a single section with the same name, though I have no idea what the sequence should be).